### PR TITLE
Add patches for FIFO Latest Ready support

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1191,7 +1191,8 @@ $(eval $(call rules-meson,dxvk,x86_64,windows))
 $(eval $(call rules-meson,dxvk,aarch64,windows))
 $(eval $(call rules-meson,dxvk,arm64ec,windows))
 
-$(OBJ)/.dxvk-post-source:
+$(OBJ)/.dxvk-post-source: patches-source
+	find $(PATCHES_SRC)/dxvk/ -name "*.patch" | sort | xargs -n1 patch -d $(DXVK_SRC) -Np1 -i
 	sed -re 's#@VCS_TAG@#$(shell git -C $(SRCDIR)/dxvk describe --always --abbrev=15 --dirty=0)#' \
 	    $(SRCDIR)/dxvk/version.h.in > $(DXVK_SRC)/version.h.in
 	mkdir -p $(DST_LIBDIR)/wine/dxvk
@@ -1607,7 +1608,8 @@ $(eval $(call rules-meson,vkd3d-proton,x86_64,windows))
 $(eval $(call rules-meson,vkd3d-proton,aarch64,windows))
 $(eval $(call rules-meson,vkd3d-proton,arm64ec,windows))
 
-$(OBJ)/.vkd3d-proton-post-source:
+$(OBJ)/.vkd3d-proton-post-source: patches-source
+	find $(PATCHES_SRC)/vkd3d-proton/ -name "*.patch" | sort | xargs -n1 patch -d $(VKD3D_PROTON_SRC) -Np1 -i
 	sed -re 's#@VCS_TAG@#$(shell git -C $(SRCDIR)/vkd3d-proton describe --always --exclude=* --abbrev=15 --dirty=0)#' \
 	    $(SRCDIR)/vkd3d-proton/vkd3d_build.h.in > $(VKD3D_PROTON_SRC)/vkd3d_build.h.in
 	sed -re 's#@VCS_TAG@#$(shell git -C $(SRCDIR)/vkd3d-proton describe --always --tags --dirty=+)#' \

--- a/patches/dxvk-llasync/dxvk-llasync-fifo_latest_ready.patch
+++ b/patches/dxvk-llasync/dxvk-llasync-fifo_latest_ready.patch
@@ -1,0 +1,112 @@
+From f59fa4eed389a5f06609932cd988324347654765 Mon Sep 17 00:00:00 2001
+From: Darin Morrison <darinmorrison@gmail.com>
+Date: Wed, 11 Mar 2026 20:17:31 -0600
+Subject: [PATCH 1/3] Add newer present mode enums to vulkan_names
+
+(cherry picked from commit d384e710a0bf2dfbe683d8def881e56e767d6e65)
+Signed-off-by: Darin Morrison <darinmorrison@gmail.com>
+---
+ src/vulkan/vulkan_names.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/vulkan/vulkan_names.cpp b/src/vulkan/vulkan_names.cpp
+index be52650e..6bacb8ec 100644
+--- a/src/vulkan/vulkan_names.cpp
++++ b/src/vulkan/vulkan_names.cpp
+@@ -298,6 +298,9 @@ std::ostream& operator << (std::ostream& os, VkPresentModeKHR e) {
+     ENUM_NAME(VK_PRESENT_MODE_MAILBOX_KHR);
+     ENUM_NAME(VK_PRESENT_MODE_FIFO_KHR);
+     ENUM_NAME(VK_PRESENT_MODE_FIFO_RELAXED_KHR);
++    ENUM_NAME(VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR);
++    ENUM_NAME(VK_PRESENT_MODE_SHARED_CONTINUOUS_REFRESH_KHR);
++    ENUM_NAME(VK_PRESENT_MODE_FIFO_LATEST_READY_EXT);
+     ENUM_DEFAULT(e);
+   }
+   return os;
+-- 
+2.53.0
+
+
+From a6fb9766d3ec660ef3aea5bd299a6926bb82c9f7 Mon Sep 17 00:00:00 2001
+From: Darin Morrison <darinmorrison@gmail.com>
+Date: Wed, 11 Mar 2026 20:15:43 -0600
+Subject: [PATCH 2/3] Prefer FIFO_LATEST_READY over MAILBOX
+
+(cherry picked from commit 1df37b45a292ed322bff5a8789b6ecabd4683652)
+Signed-off-by: Darin Morrison <darinmorrison@gmail.com>
+---
+ src/dxvk/dxvk_presenter.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/dxvk/dxvk_presenter.cpp b/src/dxvk/dxvk_presenter.cpp
+index 76de00f6..1bdd7d64 100644
+--- a/src/dxvk/dxvk_presenter.cpp
++++ b/src/dxvk/dxvk_presenter.cpp
+@@ -1080,7 +1080,7 @@ namespace dxvk {
+           uint32_t                  numSupported,
+     const VkPresentModeKHR*         pSupported,
+           uint32_t                  syncInterval) {
+-    std::array<VkPresentModeKHR, 2> desired = { };
++    std::array<VkPresentModeKHR, 3> desired = { };
+     uint32_t numDesired = 0;
+ 
+     Tristate tearFree = m_device->config().tearFree;
+@@ -1088,6 +1088,7 @@ namespace dxvk {
+     if (!syncInterval) {
+       if (tearFree != Tristate::True)
+         desired[numDesired++] = VK_PRESENT_MODE_IMMEDIATE_KHR;
++      desired[numDesired++] = VK_PRESENT_MODE_FIFO_LATEST_READY_EXT;
+       desired[numDesired++] = VK_PRESENT_MODE_MAILBOX_KHR;
+     } else {
+       if (tearFree == Tristate::False)
+-- 
+2.53.0
+
+
+From a5266cdbb1cd25781c34d75c2f43c5f9f5a9180c Mon Sep 17 00:00:00 2001
+From: Darin Morrison <darinmorrison@gmail.com>
+Date: Wed, 11 Mar 2026 20:28:22 -0600
+Subject: [PATCH 3/3] Update comments to mention FIFO latest ready
+
+(cherry picked from commit db5e8a88ebd0c144e35d74f5e735f21219cdd22e)
+Signed-off-by: Darin Morrison <darinmorrison@gmail.com>
+---
+ dxvk.conf               | 4 ++--
+ src/dxvk/dxvk_options.h | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/dxvk.conf b/dxvk.conf
+index 38f3db64..cbdb8acf 100644
+--- a/dxvk.conf
++++ b/dxvk.conf
+@@ -212,10 +212,10 @@
+ 
+ # Controls tearing behaviour with regards to in-game Vsync settings.
+ #
+-# True enables the mailbox present mode in case regular Vsync is disabled.
++# True enables the fifo (latest ready) or mailbox present modes in case regular Vsync is disabled.
+ # This eliminates tearing, but may be unsupported on some systems.
+ #
+-# False enables the relaxed fifo present mode in case regular Vsync is enabled.
++# False enables the fifo (relaxed) present mode in case regular Vsync is enabled.
+ # This should result in tearing but reduce stutter if FPS are too low,
+ # but may be unsupported on some systems.
+ #
+diff --git a/src/dxvk/dxvk_options.h b/src/dxvk/dxvk_options.h
+index a0d07d38..fdcd98a1 100644
+--- a/src/dxvk/dxvk_options.h
++++ b/src/dxvk/dxvk_options.h
+@@ -35,8 +35,8 @@ namespace dxvk {
+     /// HUD elements
+     std::string hud;
+ 
+-    /// Forces swap chain into MAILBOX (if true)
+-    /// or FIFO_RELAXED (if false) present mode
++    /// Forces swap chain into FIFO_LATEST_READY or
++    /// MAILBOX (if true) or FIFO_RELAXED (if false).
+     Tristate tearFree = Tristate::Auto;
+ 
+     /// Enables latency sleep
+-- 
+2.53.0
+

--- a/patches/dxvk/dxvk-fifo_latest_ready.patch
+++ b/patches/dxvk/dxvk-fifo_latest_ready.patch
@@ -1,0 +1,207 @@
+From 95630a639fa073dd368dc3bb0ff6e2cb6b3ca3ff Mon Sep 17 00:00:00 2001
+From: Darin Morrison <darinmorrison@gmail.com>
+Date: Wed, 11 Mar 2026 20:17:31 -0600
+Subject: [PATCH 1/4] [vulkan] Add newer present mode enums to vulkan_names
+
+(cherry picked from commit d384e710a0bf2dfbe683d8def881e56e767d6e65)
+Signed-off-by: Darin Morrison <darinmorrison@gmail.com>
+---
+ src/vulkan/vulkan_names.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/vulkan/vulkan_names.cpp b/src/vulkan/vulkan_names.cpp
+index be52650e..4831b654 100644
+--- a/src/vulkan/vulkan_names.cpp
++++ b/src/vulkan/vulkan_names.cpp
+@@ -298,6 +298,9 @@ std::ostream& operator << (std::ostream& os, VkPresentModeKHR e) {
+     ENUM_NAME(VK_PRESENT_MODE_MAILBOX_KHR);
+     ENUM_NAME(VK_PRESENT_MODE_FIFO_KHR);
+     ENUM_NAME(VK_PRESENT_MODE_FIFO_RELAXED_KHR);
++    ENUM_NAME(VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR);
++    ENUM_NAME(VK_PRESENT_MODE_SHARED_CONTINUOUS_REFRESH_KHR);
++    ENUM_NAME(VK_PRESENT_MODE_FIFO_LATEST_READY_KHR);
+     ENUM_DEFAULT(e);
+   }
+   return os;
+-- 
+2.53.0
+
+
+From 6d5e86f8da87e38e57b10d48f5d60c9c36e9c4a1 Mon Sep 17 00:00:00 2001
+From: Darin Morrison <darinmorrison@gmail.com>
+Date: Wed, 11 Mar 2026 20:15:43 -0600
+Subject: [PATCH 2/4] [dxvk] Prefer FIFO_LATEST_READY over MAILBOX
+
+(cherry picked from commit 1df37b45a292ed322bff5a8789b6ecabd4683652)
+Signed-off-by: Darin Morrison <darinmorrison@gmail.com>
+---
+ src/dxvk/dxvk_presenter.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/dxvk/dxvk_presenter.cpp b/src/dxvk/dxvk_presenter.cpp
+index f0d26515..14121c0c 100644
+--- a/src/dxvk/dxvk_presenter.cpp
++++ b/src/dxvk/dxvk_presenter.cpp
+@@ -1119,7 +1119,7 @@ namespace dxvk {
+           uint32_t                  numSupported,
+     const VkPresentModeKHR*         pSupported,
+           uint32_t                  syncInterval) {
+-    std::array<VkPresentModeKHR, 2> desired = { };
++    std::array<VkPresentModeKHR, 3> desired = { };
+     uint32_t numDesired = 0;
+ 
+     Tristate tearFree = m_device->config().tearFree;
+@@ -1127,6 +1127,7 @@ namespace dxvk {
+     if (!syncInterval) {
+       if (tearFree != Tristate::True)
+         desired[numDesired++] = VK_PRESENT_MODE_IMMEDIATE_KHR;
++      desired[numDesired++] = VK_PRESENT_MODE_FIFO_LATEST_READY_KHR;
+       desired[numDesired++] = VK_PRESENT_MODE_MAILBOX_KHR;
+     } else {
+       if (tearFree == Tristate::False)
+-- 
+2.53.0
+
+
+From 84dcf9f4dae7ec039eb5bc3da3dbd5a9a9843317 Mon Sep 17 00:00:00 2001
+From: Darin Morrison <darinmorrison@gmail.com>
+Date: Wed, 11 Mar 2026 20:28:22 -0600
+Subject: [PATCH 3/4] [dxvk] Update comments to mention FIFO latest ready
+
+(cherry picked from commit db5e8a88ebd0c144e35d74f5e735f21219cdd22e)
+Signed-off-by: Darin Morrison <darinmorrison@gmail.com>
+---
+ dxvk.conf               | 4 ++--
+ src/dxvk/dxvk_options.h | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/dxvk.conf b/dxvk.conf
+index de815a22..cbadb5fd 100644
+--- a/dxvk.conf
++++ b/dxvk.conf
+@@ -217,10 +217,10 @@
+ 
+ # Controls tearing behaviour with regards to in-game Vsync settings.
+ #
+-# True enables the mailbox present mode in case regular Vsync is disabled.
++# True enables the fifo (latest ready) or mailbox present modes in case regular Vsync is disabled.
+ # This eliminates tearing, but may be unsupported on some systems.
+ #
+-# False enables the relaxed fifo present mode in case regular Vsync is enabled.
++# False enables the fifo (relaxed) present mode in case regular Vsync is enabled.
+ # This should result in tearing but reduce stutter if FPS are too low,
+ # but may be unsupported on some systems.
+ #
+diff --git a/src/dxvk/dxvk_options.h b/src/dxvk/dxvk_options.h
+index 71deb596..960d8108 100644
+--- a/src/dxvk/dxvk_options.h
++++ b/src/dxvk/dxvk_options.h
+@@ -41,8 +41,8 @@ namespace dxvk {
+     /// HUD elements
+     std::string hud;
+ 
+-    /// Forces swap chain into MAILBOX (if true)
+-    /// or FIFO_RELAXED (if false) present mode
++    /// Forces swap chain into FIFO_LATEST_READY or
++    /// MAILBOX (if true) or FIFO_RELAXED (if false).
+     Tristate tearFree = Tristate::Auto;
+ 
+     /// Enables latency sleep
+-- 
+2.53.0
+
+
+From 1ed5f93efc0c0ff5b792740dd911a2c44a996cc1 Mon Sep 17 00:00:00 2001
+From: Darin Morrison <darinmorrison@gmail.com>
+Date: Thu, 12 Mar 2026 13:49:09 -0600
+Subject: [PATCH 4/4] [dxvk] Add feature enable for FIFO_LATEST_READY
+
+(cherry picked from commit 1956b0ab9a5c36a787e10d07730f053d763dd5ed)
+Signed-off-by: Darin Morrison <darinmorrison@gmail.com>
+---
+ src/dxvk/dxvk_device_info.cpp | 4 ++++
+ src/dxvk/dxvk_device_info.h   | 2 ++
+ src/dxvk/dxvk_presenter.cpp   | 5 ++++-
+ src/dxvk/dxvk_presenter.h     | 1 +
+ 4 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/src/dxvk/dxvk_device_info.cpp b/src/dxvk/dxvk_device_info.cpp
+index ef5bf596..fab68a00 100644
+--- a/src/dxvk/dxvk_device_info.cpp
++++ b/src/dxvk/dxvk_device_info.cpp
+@@ -55,6 +55,7 @@ namespace dxvk {
+     HANDLE_EXT(khrPipelineLibrary);                \
+     HANDLE_EXT(khrPresentId);                      \
+     HANDLE_EXT(khrPresentId2);                     \
++    HANDLE_EXT(khrPresentModeFifoLatestReady);     \
+     HANDLE_EXT(khrPresentWait);                    \
+     HANDLE_EXT(khrPresentWait2);                   \
+     HANDLE_EXT(khrShaderFloatControls2);           \
+@@ -991,6 +992,9 @@ namespace dxvk {
+       /* Dependency for graphics pipeline library */
+       ENABLE_EXT(khrPipelineLibrary, true),
+ 
++      /* Present mode FIFO Latest Ready */
++      ENABLE_EXT_FEATURE(khrPresentModeFifoLatestReady, presentModeFifoLatestReady, false),
++
+       /* Present wait, used for frame pacing and statistics */
+       ENABLE_EXT_FEATURE(khrPresentId, presentId, false),
+       ENABLE_EXT_FEATURE(khrPresentId2, presentId2, false),
+diff --git a/src/dxvk/dxvk_device_info.h b/src/dxvk/dxvk_device_info.h
+index 3f6af060..43cfe40e 100644
+--- a/src/dxvk/dxvk_device_info.h
++++ b/src/dxvk/dxvk_device_info.h
+@@ -95,6 +95,7 @@ namespace dxvk {
+     VkPhysicalDeviceMaintenance9FeaturesKHR                   khrMaintenance9                 = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_9_FEATURES_KHR };
+     VkPhysicalDeviceMaintenance10FeaturesKHR                  khrMaintenance10                = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_10_FEATURES_KHR };
+     VkBool32                                                  khrPipelineLibrary              = VK_FALSE;
++    VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR     khrPresentModeFifoLatestReady   = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_MODE_FIFO_LATEST_READY_FEATURES_KHR };
+     VkPhysicalDevicePresentIdFeaturesKHR                      khrPresentId                    = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_ID_FEATURES_KHR };
+     VkPhysicalDevicePresentId2FeaturesKHR                     khrPresentId2                   = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_ID_2_FEATURES_KHR };
+     VkPhysicalDevicePresentWaitFeaturesKHR                    khrPresentWait                  = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_WAIT_FEATURES_KHR };
+@@ -164,6 +165,7 @@ namespace dxvk {
+     VkExtensionProperties khrMaintenance9                   = vk::makeExtension(VK_KHR_MAINTENANCE_9_EXTENSION_NAME);
+     VkExtensionProperties khrMaintenance10                  = vk::makeExtension(VK_KHR_MAINTENANCE_10_EXTENSION_NAME);
+     VkExtensionProperties khrPipelineLibrary                = vk::makeExtension(VK_KHR_PIPELINE_LIBRARY_EXTENSION_NAME);
++    VkExtensionProperties khrPresentModeFifoLatestReady     = vk::makeExtension(VK_KHR_PRESENT_MODE_FIFO_LATEST_READY_EXTENSION_NAME);
+     VkExtensionProperties khrPresentId                      = vk::makeExtension(VK_KHR_PRESENT_ID_EXTENSION_NAME);
+     VkExtensionProperties khrPresentId2                     = vk::makeExtension(VK_KHR_PRESENT_ID_2_EXTENSION_NAME);
+     VkExtensionProperties khrPresentWait                    = vk::makeExtension(VK_KHR_PRESENT_WAIT_EXTENSION_NAME);
+diff --git a/src/dxvk/dxvk_presenter.cpp b/src/dxvk/dxvk_presenter.cpp
+index 14121c0c..9f3d4dad 100644
+--- a/src/dxvk/dxvk_presenter.cpp
++++ b/src/dxvk/dxvk_presenter.cpp
+@@ -853,6 +853,8 @@ namespace dxvk {
+ 
+     m_dynamicModes = std::move(dynamicModes);
+ 
++    m_hasPresentModeFifoLatestReady = m_device->features().khrPresentModeFifoLatestReady.presentModeFifoLatestReady;
++
+     // Set up feature support for present wait / id, and launch sync thread as necessary
+     m_hasPresentId = presentId2Caps.presentId2Supported || m_device->features().khrPresentId.presentId;
+     m_hasPresentWait = presentWait2Caps.presentWait2Supported || m_device->features().khrPresentWait.presentWait;
+@@ -1127,7 +1129,8 @@ namespace dxvk {
+     if (!syncInterval) {
+       if (tearFree != Tristate::True)
+         desired[numDesired++] = VK_PRESENT_MODE_IMMEDIATE_KHR;
+-      desired[numDesired++] = VK_PRESENT_MODE_FIFO_LATEST_READY_KHR;
++      if (m_hasPresentModeFifoLatestReady)
++        desired[numDesired++] = VK_PRESENT_MODE_FIFO_LATEST_READY_KHR;
+       desired[numDesired++] = VK_PRESENT_MODE_MAILBOX_KHR;
+     } else {
+       if (tearFree == Tristate::False)
+diff --git a/src/dxvk/dxvk_presenter.h b/src/dxvk/dxvk_presenter.h
+index 48fa2928..2b8ff5ec 100644
+--- a/src/dxvk/dxvk_presenter.h
++++ b/src/dxvk/dxvk_presenter.h
+@@ -289,6 +289,7 @@ namespace dxvk {
+     bool                        m_dirtySwapchain = false;
+     bool                        m_dirtySurface = false;
+ 
++    bool                        m_hasPresentModeFifoLatestReady = false;
+     bool                        m_hasPresentId = false;
+     bool                        m_hasPresentWait = false;
+     bool                        m_hasSwapchainMaintenance1 = false;
+-- 
+2.53.0
+

--- a/patches/vkd3d-proton/vkd3d-proton-fifo_latest_ready.patch
+++ b/patches/vkd3d-proton/vkd3d-proton-fifo_latest_ready.patch
@@ -1,0 +1,199 @@
+From 4fee3b0ce35daa94508714bb4445ea51b865b5cb Mon Sep 17 00:00:00 2001
+From: Darin Morrison <darinmorrison@gmail.com>
+Date: Thu, 12 Mar 2026 10:37:48 -0600
+Subject: [PATCH 1/2] vkd3d: Support VK_PRESENT_MODE_FIFO_LATEST_READY_KHR.
+
+This commit allows the newer present mode
+VK_PRESENT_MODE_FIFO_LATEST_READY_KHR to be selected when finding a
+compatible unlocked present mode.
+
+The precedence for selecting an unlocked present mode now follows:
+
+1. Immediate
+2. FIFO Latest Ready
+3. Mailbox
+
+(cherry picked from commit 74fece7f865e9cf89851effc3bb56803c495c652)
+Signed-off-by: Darin Morrison <darinmorrison@gmail.com>
+---
+ libs/vkd3d/device.c        |  7 +++++++
+ libs/vkd3d/swapchain.c     | 12 ++++++++++++
+ libs/vkd3d/vkd3d_private.h |  2 ++
+ 3 files changed, 21 insertions(+)
+
+diff --git a/libs/vkd3d/device.c b/libs/vkd3d/device.c
+index e445f6e9..6d3b6baf 100644
+--- a/libs/vkd3d/device.c
++++ b/libs/vkd3d/device.c
+@@ -75,6 +75,7 @@ static const struct vkd3d_optional_extension_info optional_device_extensions[] =
+     VK_EXTENSION_DISABLE_COND(KHR_RAY_TRACING_MAINTENANCE_1, KHR_ray_tracing_maintenance1, VKD3D_CONFIG_FLAG_NO_DXR),
+     VK_EXTENSION(KHR_FRAGMENT_SHADING_RATE, KHR_fragment_shading_rate),
+     VK_EXTENSION(KHR_FRAGMENT_SHADER_BARYCENTRIC, KHR_fragment_shader_barycentric),
++    VK_EXTENSION(KHR_PRESENT_MODE_FIFO_LATEST_READY, KHR_present_mode_fifo_latest_ready),
+     VK_EXTENSION(KHR_PRESENT_ID, KHR_present_id),
+     VK_EXTENSION(KHR_PRESENT_WAIT, KHR_present_wait),
+     VK_EXTENSION(KHR_MAINTENANCE_5, KHR_maintenance5),
+@@ -2002,6 +2003,12 @@ static void vkd3d_physical_device_info_init(struct vkd3d_physical_device_info *i
+         vk_prepend_struct(&info->features2, &info->present_id_features);
+     }
+ 
++    if (vulkan_info->KHR_present_mode_fifo_latest_ready)
++    {
++        info->present_mode_fifo_latest_ready_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_MODE_FIFO_LATEST_READY_FEATURES_KHR;
++        vk_prepend_struct(&info->features2, &info->present_mode_fifo_latest_ready_features);
++    }
++
+     if (vulkan_info->KHR_present_wait)
+     {
+         info->present_wait_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_WAIT_FEATURES_KHR;
+diff --git a/libs/vkd3d/swapchain.c b/libs/vkd3d/swapchain.c
+index aad9d7d4..419d7578 100644
+--- a/libs/vkd3d/swapchain.c
++++ b/libs/vkd3d/swapchain.c
+@@ -1684,6 +1684,18 @@ static bool dxgi_vk_swap_chain_find_compatible_unlocked_present_mode(
+         }
+     }
+ 
++    if (chain->queue->device->device_info.present_mode_fifo_latest_ready_features.presentModeFifoLatestReady)
++    {
++        for (i = 0; !has_compatible && i < compat.presentModeCount; i++)
++        {
++            if (compat.pPresentModes[i] == VK_PRESENT_MODE_FIFO_LATEST_READY_KHR)
++            {
++                *vk_present_mode = VK_PRESENT_MODE_FIFO_LATEST_READY_KHR;
++                has_compatible = true;
++            }
++        }
++    }
++
+     for (i = 0; !has_compatible && i < compat.presentModeCount; i++)
+     {
+         if (compat.pPresentModes[i] == VK_PRESENT_MODE_MAILBOX_KHR)
+diff --git a/libs/vkd3d/vkd3d_private.h b/libs/vkd3d/vkd3d_private.h
+index 535bcd40..d8960dd8 100644
+--- a/libs/vkd3d/vkd3d_private.h
++++ b/libs/vkd3d/vkd3d_private.h
+@@ -148,6 +148,7 @@ struct vkd3d_vulkan_info
+     bool KHR_calibrated_timestamps;
+     bool KHR_cooperative_matrix;
+     bool KHR_unified_image_layouts;
++    bool KHR_present_mode_fifo_latest_ready;
+     /* EXT device extensions */
+     bool EXT_conditional_rendering;
+     bool EXT_conservative_rasterization;
+@@ -5031,6 +5032,7 @@ struct vkd3d_physical_device_info
+     VkPhysicalDeviceAntiLagFeaturesAMD anti_lag_amd;
+     VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR unified_image_layouts_features;
+     VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE shader_mixed_float_dot_product_features;
++    VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR present_mode_fifo_latest_ready_features;
+ 
+     VkPhysicalDeviceFeatures2 features2;
+ 
+-- 
+2.53.0
+
+
+From cce8ebf7d20dcce1baaa7b3e60012be1e7afb258 Mon Sep 17 00:00:00 2001
+From: Darin Morrison <darinmorrison@gmail.com>
+Date: Thu, 12 Mar 2026 10:51:44 -0600
+Subject: [PATCH 2/2] vkd3d: Add "tear_free" VKD3D_CONFIG option.
+
+The "tear_free" option changes the behavior when finding a compatible
+unlocked present mode to prefer tear-free modes.
+
+The precedence for seleccting an unlocked present mode now follows:
+
+1. FIFO Latest Ready
+2. Mailbox
+3. Immediate
+
+This is intended to be similar to the "dxvk.tearFree" option for dxvk.
+
+(cherry picked from commit 099a83ad8a436fa664881010ebca054b88c148a5)
+Signed-off-by: Darin Morrison <darinmorrison@gmail.com>
+---
+ README.md              | 1 +
+ include/vkd3d.h        | 1 +
+ libs/vkd3d/device.c    | 1 +
+ libs/vkd3d/swapchain.c | 8 ++++++--
+ 4 files changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/README.md b/README.md
+index faa56845..32277e41 100644
+--- a/README.md
++++ b/README.md
+@@ -156,6 +156,7 @@ commas or semicolons.
+       so it should not be a real issue even on lower VRAM cards.
+     - `force_host_cached` - Forces all host visible allocations to be CACHED, which greatly accelerates captures.
+     - `no_invariant_position` - Avoids workarounds for invariant position. The workaround is enabled by default.
++    - `tear_free` - Prefer tear-free present modes when Vsync is disabled. Selects FIFO Latest Ready or Mailbox before Immediate.
+  - `VKD3D_DEBUG` - controls the debug level for log messages produced by
+    vkd3d-proton. Accepts the following values: none, err, info, fixme, warn, trace.
+  - `VKD3D_SHADER_DEBUG` - controls the debug level for log messages produced by
+diff --git a/include/vkd3d.h b/include/vkd3d.h
+index c467b5d2..98726d85 100644
+--- a/include/vkd3d.h
++++ b/include/vkd3d.h
+@@ -120,6 +120,7 @@ extern "C" {
+ #define VKD3D_CONFIG_FLAG_DEFER_RESOURCE_DESTRUCTION (1ull << 60)
+ #define VKD3D_CONFIG_FLAG_PREFER_THIN_UAV_TILING (1ull << 61)
+ #define VKD3D_CONFIG_FLAG_EXTENDED_DEBUG_UTILS (1ull << 62)
++#define VKD3D_CONFIG_FLAG_TEAR_FREE (1ull << 63)
+ 
+ struct vkd3d_instance;
+ 
+diff --git a/libs/vkd3d/device.c b/libs/vkd3d/device.c
+index 6d3b6baf..7fe355c4 100644
+--- a/libs/vkd3d/device.c
++++ b/libs/vkd3d/device.c
+@@ -1198,6 +1198,7 @@ static const struct vkd3d_debug_option vkd3d_config_options[] =
+     {"damage_not_zeroed_allocations", VKD3D_CONFIG_FLAG_DAMAGE_NOT_ZEROED_ALLOCATIONS},
+     {"defer_resource_destruction", VKD3D_CONFIG_FLAG_DEFER_RESOURCE_DESTRUCTION},
+     {"prefer_thin_uav_tiling", VKD3D_CONFIG_FLAG_PREFER_THIN_UAV_TILING},
++    {"tear_free", VKD3D_CONFIG_FLAG_TEAR_FREE},
+ };
+ 
+ static void vkd3d_config_flags_init_once(void)
+diff --git a/libs/vkd3d/swapchain.c b/libs/vkd3d/swapchain.c
+index 419d7578..cffbe1be 100644
+--- a/libs/vkd3d/swapchain.c
++++ b/libs/vkd3d/swapchain.c
+@@ -1650,6 +1650,8 @@ static bool dxgi_vk_swap_chain_find_compatible_unlocked_present_mode(
+     VkPresentModeKHR present_modes[32];
+     VkSurfaceCapabilities2KHR caps2;
+     bool has_compatible = false;
++    bool has_compatible_tear_free = false;
++    bool prefer_tear_free = vkd3d_config_flags & VKD3D_CONFIG_FLAG_TEAR_FREE;
+     uint32_t i;
+ 
+     /* swapchain maintenance implies surface maintenance */
+@@ -1686,22 +1688,24 @@ static bool dxgi_vk_swap_chain_find_compatible_unlocked_present_mode(
+ 
+     if (chain->queue->device->device_info.present_mode_fifo_latest_ready_features.presentModeFifoLatestReady)
+     {
+-        for (i = 0; !has_compatible && i < compat.presentModeCount; i++)
++        for (i = 0; (!has_compatible || (prefer_tear_free && !has_compatible_tear_free)) && i < compat.presentModeCount; i++)
+         {
+             if (compat.pPresentModes[i] == VK_PRESENT_MODE_FIFO_LATEST_READY_KHR)
+             {
+                 *vk_present_mode = VK_PRESENT_MODE_FIFO_LATEST_READY_KHR;
+                 has_compatible = true;
++                has_compatible_tear_free = true;
+             }
+         }
+     }
+ 
+-    for (i = 0; !has_compatible && i < compat.presentModeCount; i++)
++    for (i = 0; (!has_compatible || (prefer_tear_free && !has_compatible_tear_free)) && i < compat.presentModeCount; i++)
+     {
+         if (compat.pPresentModes[i] == VK_PRESENT_MODE_MAILBOX_KHR)
+         {
+             *vk_present_mode = VK_PRESENT_MODE_MAILBOX_KHR;
+             has_compatible = true;
++            has_compatible_tear_free = true;
+         }
+     }
+ 
+-- 
+2.53.0
+


### PR DESCRIPTION
This PR adds patches for `VK_PRESENT_MODE_FIFO_LATEST_READY_KHR`.

Both `dxvk` and `vkd3d-proton` are modified.

FIFO Latest Ready is preferred over Mailbox when supported.

The second change adds a new option `VKD3D_CONFIG=tear_free`. If specified, this option changes the behavior when finding the unlocked mode to prefer tear-free modes, so FIFO Latest Ready or Mailbox will be chosen before Immediate.

The new option is intended to be similar in behavior to [`dxvk.tearFree`](https://github.com/doitsujin/dxvk/blob/3730b707223a273fb1774f2f2ac3572d68c4dbe9/src/dxvk/dxvk_options.h#L44-L46). This also makes it possible to override an application to use an unlocked tear-free mode:
```
DXVK_CONFIG="dxgi.syncInterval = 0" VKD3D_CONFIG=tear_free
```

These patches are taken from the respective upstream PRs:

- https://github.com/doitsujin/dxvk/pull/5550
- https://github.com/HansKristian-Work/vkd3d-proton/pull/2874

I'm submitting the patches here in the meantime in case someone wants to try them out with proton.

Tested working on an NVIDIA GeForce RTX 5090 with driver 595.45.04.